### PR TITLE
Update de.po

### DIFF
--- a/locale/de/de.po
+++ b/locale/de/de.po
@@ -8,78 +8,74 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-04-20 13:14+0200\n"
-"PO-Revision-Date: 2016-05-17 17:31+0200\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2020-10-26 20:51+0100\n"
+"Last-Translator: Onno Giesmann <nutzer3105@gmail.com>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.7\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: extension.js:216
 #, javascript-format
 msgid "Group of %d application"
 msgid_plural "Group of %d applications"
-msgstr[0] "Gruppe von %d Anwendung"
-msgstr[1] "Gruppe von %d Anwendungen"
+msgstr[0] "Gruppe mit %d Anwendung"
+msgstr[1] "Gruppe mit %d Anwendungen"
 
 #: prefs.xml:37
 msgid "Application title / Group name"
-msgstr ""
+msgstr "Anwendungsname / Gruppenname"
 
 #: prefs.xml:52 prefs.xml:106 prefs.xml:142
 msgid "Show in tooltip"
-msgstr ""
+msgstr "In Minihilfe anzeigen"
 
 #: prefs.xml:70
-#, fuzzy
 msgid "Show even if the icon-label is not elipsized"
-msgstr "Tooltips auch dann zeigen, wenn die Beschriftung nicht gekürzt ist"
+msgstr "Auch dann anzeigen, wenn die Beschriftung nicht gekürzt ist"
 
 #: prefs.xml:91
 msgid "Application description"
-msgstr ""
+msgstr "Anwendungsbeschreibung"
 
 #: prefs.xml:127
-#, fuzzy
 msgid "Application count on groups"
-msgstr "Anzahl der Anwendungen in Gruppen anzeigen"
+msgstr "Anzahl der Anwendungen in Gruppen"
 
 #: prefs.xml:163
 msgid "Tooltip style"
-msgstr ""
+msgstr "Aussehen der Minihilfe"
 
 #: prefs.xml:178
 msgid "Draw borders"
 msgstr "Rahmen anzeigen"
 
 #: prefs.xml:199
-#, fuzzy
 msgid "Tooltip appearance"
-msgstr "<b>Tooltip-Darstellung</b>"
+msgstr "Erscheinungsbild der Minihilfe"
 
 #: prefs.xml:216
-#, fuzzy
 msgid "Timings"
-msgstr "<b>Anzeigedauer</b>"
+msgstr "Animationszeiten"
 
 #: prefs.xml:231
 msgid "Hover time before the tooltip is displayed (in ms)"
-msgstr "Wartezeit, bevor der Tooltip angezeigt wird (in ms)"
+msgstr "Wartezeit, bevor die Minihilfe angezeigt wird (in ms)"
 
 #: prefs.xml:251
 msgid "Tooltip display animation duration (in ms)"
-msgstr "Tooltip Einblend-Animationsdauer (in ms)"
+msgstr "Einblende-Animationsdauer der Minihilfe (in ms)"
 
 #: prefs.xml:271
 msgid "Tooltip dismiss animation duration (in ms)"
-msgstr "Tooltip Ausblend-Animationsdauer (in ms)"
+msgstr "Ausblende-Animationsdauer der Minihilfe (in ms)"
 
 #: prefs.xml:293
 msgid "Advanced settings"
-msgstr ""
+msgstr "Erweiterte Einstellungen"
 
 #~ msgid "<b>When to show Tooltip</b>"
 #~ msgstr "<b>Tooltip Anzeigeoptionen</b>"


### PR DESCRIPTION
Did some improvements to the localization and changed "tooltip" to "Minihilfe" (as its used in other GNOME-translations into German).